### PR TITLE
feat: Ajustes JPA N+1 e geração de pedido e itens do pedido.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,50 @@ Request body:
 ```
 
 Os possíveis status dos pedidos são: REALIZADO, CANCELADO, PREPARACAO e PRONTO.
+
+## Inicializar pedido
+
+Um pedido deve ser inicializado para que, posteriormente, os pedidos sejam inseridos. Para geração do pedido, executar o seguinte endpoint:
+
+```sh
+POST http://localhost:8080/api/pedidos
+
+Request body: 
+{
+    "status" : "GERACAO"
+}
+```
+
+## Adicionar itens ao pedido
+
+Para inclusão de itens a um pedido aberto, executar o seguinte endpoint:
+
+```sh
+POST http://localhost:8080/api/pedidos/{id_pedido}/itens
+
+Request body: 
+{
+    "quantidade" : 1,
+    "produtoId" : 4 
+}
+```
+
+## Adicionar produtos por categoria
+
+Para inclusão de produtos por categoria, executar o seguinte endpoint:
+
+```sh
+POST http://localhost:8080/api/produtos
+
+Request body: 
+{
+ "nome": "Cheeseburger",
+ "categoria": {
+   "id": 1,
+   "nome": "Lanche"
+ },
+ "preco" : "39.90",
+ "descricao" : "Carne bovina de 120G. Duas fatias de queijo cheedar.",
+ "imagem" : "/imgs/products/cheeseburger.png"
+}
+```

--- a/src/main/java/com/techchallenge/adapter/driver/PedidoController.java
+++ b/src/main/java/com/techchallenge/adapter/driver/PedidoController.java
@@ -1,19 +1,41 @@
 package com.techchallenge.adapter.driver;
 
-import com.techchallenge.adapter.driver.exceptionhandler.Problem;
-import com.techchallenge.adapter.driver.model.PedidoModel;
-import com.techchallenge.adapter.mapper.PedidoMapper;
-import com.techchallenge.core.applications.service.PedidoService;
-import com.techchallenge.core.domain.Pedido;
-import com.techchallenge.core.domain.StatusPedido;
-import io.swagger.annotations.*;
+import java.util.Collection;
+import java.util.List;
+
+import javax.validation.Valid;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
 
-import java.util.Collection;
-import java.util.List;
+import com.techchallenge.adapter.driver.exceptionhandler.Problem;
+import com.techchallenge.adapter.driver.model.ItemPedidoModel;
+import com.techchallenge.adapter.driver.model.PedidoModel;
+import com.techchallenge.adapter.driver.model.input.ItemPedidoInput;
+import com.techchallenge.adapter.driver.model.input.PedidoInput;
+import com.techchallenge.adapter.mapper.ItemPedidoMapper;
+import com.techchallenge.adapter.mapper.PedidoMapper;
+import com.techchallenge.core.applications.service.ItemPedidoService;
+import com.techchallenge.core.applications.service.PedidoService;
+import com.techchallenge.core.domain.ItemPedido;
+import com.techchallenge.core.domain.Pedido;
+import com.techchallenge.core.domain.StatusPedido;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 @Api(tags = "Pedidos")
 @RestController
@@ -22,9 +44,15 @@ public class PedidoController {
 
     @Autowired
     private PedidoService service;
+    
+    @Autowired
+    private ItemPedidoService itemPedidoService;
 
     @Autowired
     private PedidoMapper mapper;
+    
+    @Autowired
+    private ItemPedidoMapper itemPedidoMapper;
 
     @ApiOperation("Consulta pedido pelo ID do pedido")
     @ApiResponses({
@@ -65,5 +93,31 @@ public class PedidoController {
         StatusPedido statusPedido = StatusPedido.valueOf(novoStatus);
         service.atualizarStatusDoPedido(pedido, statusPedido);
     }
+    
+	@ApiOperation("Inicializa um pedido na plataforma")
+	@ApiResponses({ 
+			@ApiResponse(code = 201, message = "Pedido inicializado com sucesso") 
+			})
+	@PostMapping
+	@ResponseStatus(HttpStatus.CREATED)
+	public PedidoModel inicializar(@RequestBody @Valid PedidoInput input) {
+		Pedido pedido = mapper.toDomainObject(input);
+		pedido = service.inicializar(pedido);
+
+		return mapper.toModel(pedido);
+	}
+	
+	@ApiOperation("Adicionar itens ao pedido na plataforma")
+	@ApiResponses({ 
+			@ApiResponse(code = 201, message = "Itens atualizados com sucesso") 
+			})
+	@PostMapping(value = "/{id}/items")
+	@ResponseStatus(HttpStatus.OK)
+	public ItemPedidoModel adicionarProduto(@PathVariable Long id, @RequestBody @Valid ItemPedidoInput input) {
+		ItemPedido itemPedido = itemPedidoMapper.toDomainObject(input);
+		itemPedido = itemPedidoService.adicionarItemAoPedido(id, itemPedido);
+
+		return itemPedidoMapper.toModel(itemPedido);
+	}
 
 }

--- a/src/main/java/com/techchallenge/adapter/driver/ProdutoController.java
+++ b/src/main/java/com/techchallenge/adapter/driver/ProdutoController.java
@@ -1,21 +1,31 @@
 package com.techchallenge.adapter.driver;
 
+import java.util.Collection;
+import java.util.List;
+
+import javax.validation.Valid;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
 import com.techchallenge.adapter.driver.model.ProdutoModel;
+import com.techchallenge.adapter.driver.model.input.ProdutoInput;
 import com.techchallenge.adapter.mapper.ProdutoMapper;
 import com.techchallenge.core.applications.service.ProdutoService;
 import com.techchallenge.core.domain.Produto;
 
 import io.swagger.annotations.Api;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
-import java.util.Collection;
-import java.util.List;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 
 @Api(tags = "Produtos")
 @RestController
@@ -39,4 +49,17 @@ public class ProdutoController {
         List<Produto> produto = service.buscarPorCategoria(categoria);
         return mapper.toCollectionModel(produto);
     }
+    
+	@ApiOperation("Inclui um produto na plataforma")
+	@ApiResponses({ 
+			@ApiResponse(code = 201, message = "Produto incluso com sucesso") 
+			})
+	@PostMapping
+	@ResponseStatus(HttpStatus.CREATED)
+	public ProdutoModel adicionar(@RequestBody @Valid ProdutoInput input) {
+		Produto produto = mapper.toDomainObject(input);
+		produto = service.salvar(produto);
+
+		return mapper.toModel(produto);
+	}
 }

--- a/src/main/java/com/techchallenge/adapter/driver/model/CategoriaModel.java
+++ b/src/main/java/com/techchallenge/adapter/driver/model/CategoriaModel.java
@@ -2,12 +2,22 @@ package com.techchallenge.adapter.driver.model;
 
 public class CategoriaModel {
 
-    private String nome;
+	private Long id;
+	private String nome;
 
-    public String getNome() {
-        return nome;
-    }
-    public void setNome(String nome) {
-        this.nome = nome;
-    }
+	public String getNome() {
+		return nome;
+	}
+
+	public void setNome(String nome) {
+		this.nome = nome;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
 }

--- a/src/main/java/com/techchallenge/adapter/driver/model/PedidoModel.java
+++ b/src/main/java/com/techchallenge/adapter/driver/model/PedidoModel.java
@@ -8,6 +8,7 @@ import java.time.OffsetDateTime;
 import java.util.List;
 
 public class PedidoModel {
+	private Long id;
     private List<ItemPedidoModel> itens;
     private BigDecimal valor;
     private TipoPagamento tipoPagamento;
@@ -81,4 +82,12 @@ public class PedidoModel {
     public void setDataFinalizacao(OffsetDateTime dataFinalizacao) {
         this.dataFinalizacao = dataFinalizacao;
     }
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
 }

--- a/src/main/java/com/techchallenge/adapter/driver/model/input/ItemPedidoInput.java
+++ b/src/main/java/com/techchallenge/adapter/driver/model/input/ItemPedidoInput.java
@@ -1,0 +1,24 @@
+package com.techchallenge.adapter.driver.model.input;
+
+public class ItemPedidoInput {
+
+	private Integer quantidade;
+
+	private Long produtoId;
+
+	public Integer getQuantidade() {
+		return quantidade;
+	}
+
+	public void setQuantidade(Integer quantidade) {
+		this.quantidade = quantidade;
+	}
+
+	public Long getProdutoId() {
+		return produtoId;
+	}
+
+	public void setProdutoId(Long produtoId) {
+		this.produtoId = produtoId;
+	}
+}

--- a/src/main/java/com/techchallenge/adapter/driver/model/input/PedidoInput.java
+++ b/src/main/java/com/techchallenge/adapter/driver/model/input/PedidoInput.java
@@ -1,4 +1,84 @@
 package com.techchallenge.adapter.driver.model.input;
 
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import com.techchallenge.core.domain.StatusPedido;
+
 public class PedidoInput {
+
+	private List<ItemPedidoInput> itens;
+	private BigDecimal valor;
+	private TipoPagamentoInput tipoPagamento;
+	private StatusPedido status;
+	private ClienteInput cliente;
+
+	private OffsetDateTime dataSolicitacao;
+	private OffsetDateTime dataCancelamento;
+	private OffsetDateTime dataFinalizacao;
+
+	public List<ItemPedidoInput> getItens() {
+		return itens;
+	}
+
+	public void setItens(List<ItemPedidoInput> itens) {
+		this.itens = itens;
+	}
+
+	public BigDecimal getValor() {
+		return valor;
+	}
+
+	public void setValor(BigDecimal valor) {
+		this.valor = valor;
+	}
+
+	public TipoPagamentoInput getTipoPagamento() {
+		return tipoPagamento;
+	}
+
+	public void setTipoPagamento(TipoPagamentoInput tipoPagamento) {
+		this.tipoPagamento = tipoPagamento;
+	}
+
+	public StatusPedido getStatus() {
+		return status;
+	}
+
+	public void setStatus(StatusPedido status) {
+		this.status = status;
+	}
+
+	public ClienteInput getCliente() {
+		return cliente;
+	}
+
+	public void setCliente(ClienteInput cliente) {
+		this.cliente = cliente;
+	}
+
+	public OffsetDateTime getDataSolicitacao() {
+		return dataSolicitacao;
+	}
+
+	public void setDataSolicitacao(OffsetDateTime dataSolicitacao) {
+		this.dataSolicitacao = dataSolicitacao;
+	}
+
+	public OffsetDateTime getDataCancelamento() {
+		return dataCancelamento;
+	}
+
+	public void setDataCancelamento(OffsetDateTime dataCancelamento) {
+		this.dataCancelamento = dataCancelamento;
+	}
+
+	public OffsetDateTime getDataFinalizacao() {
+		return dataFinalizacao;
+	}
+
+	public void setDataFinalizacao(OffsetDateTime dataFinalizacao) {
+		this.dataFinalizacao = dataFinalizacao;
+	}
 }

--- a/src/main/java/com/techchallenge/adapter/driver/model/input/TipoPagamentoInput.java
+++ b/src/main/java/com/techchallenge/adapter/driver/model/input/TipoPagamentoInput.java
@@ -1,0 +1,5 @@
+package com.techchallenge.adapter.driver.model.input;
+
+public class TipoPagamentoInput {
+
+}

--- a/src/main/java/com/techchallenge/adapter/mapper/ItemPedidoMapper.java
+++ b/src/main/java/com/techchallenge/adapter/mapper/ItemPedidoMapper.java
@@ -1,0 +1,39 @@
+package com.techchallenge.adapter.mapper;
+
+import java.util.Collection;
+import java.util.stream.Collectors;
+
+import org.modelmapper.ModelMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.techchallenge.adapter.driver.model.ItemPedidoModel;
+import com.techchallenge.adapter.driver.model.input.ItemPedidoInput;
+import com.techchallenge.core.domain.ItemPedido;
+import com.techchallenge.core.domain.Produto;
+
+@Component
+public class ItemPedidoMapper {
+
+    @Autowired
+    private ModelMapper mapper;
+
+    public ItemPedido toDomainObject(ItemPedidoInput input) {
+        ItemPedido itemPedido = mapper.map(input, ItemPedido.class);
+        
+        itemPedido.setProduto(new Produto());
+        itemPedido.getProduto().setId(input.getProdutoId());
+        
+        return itemPedido;
+    }
+
+    public ItemPedidoModel toModel(ItemPedido itemPedido) {
+        return mapper.map(itemPedido, ItemPedidoModel.class);
+    }
+
+    public Collection<ItemPedidoModel> toCollectionModel(Collection<ItemPedido> itens) {
+        return itens.stream()
+                .map(c -> mapper.map(c, ItemPedidoModel.class))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/techchallenge/adapter/mapper/PedidoMapper.java
+++ b/src/main/java/com/techchallenge/adapter/mapper/PedidoMapper.java
@@ -1,17 +1,15 @@
 package com.techchallenge.adapter.mapper;
 
-import com.techchallenge.adapter.driver.model.ClienteModel;
-import com.techchallenge.adapter.driver.model.PedidoModel;
-import com.techchallenge.adapter.driver.model.input.ClienteInput;
-import com.techchallenge.adapter.driver.model.input.PedidoInput;
-import com.techchallenge.core.domain.Cliente;
-import com.techchallenge.core.domain.Pedido;
+import java.util.Collection;
+import java.util.stream.Collectors;
+
 import org.modelmapper.ModelMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
-import java.util.Collection;
-import java.util.stream.Collectors;
+import com.techchallenge.adapter.driver.model.PedidoModel;
+import com.techchallenge.adapter.driver.model.input.PedidoInput;
+import com.techchallenge.core.domain.Pedido;
 
 @Component
 public class PedidoMapper {

--- a/src/main/java/com/techchallenge/core/applications/ports/ItemPedidoRepository.java
+++ b/src/main/java/com/techchallenge/core/applications/ports/ItemPedidoRepository.java
@@ -1,0 +1,11 @@
+package com.techchallenge.core.applications.ports;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.techchallenge.core.domain.ItemPedido;
+
+@Repository
+public interface ItemPedidoRepository extends JpaRepository<ItemPedido, Long> {
+
+}

--- a/src/main/java/com/techchallenge/core/applications/ports/ProdutoRepository.java
+++ b/src/main/java/com/techchallenge/core/applications/ports/ProdutoRepository.java
@@ -1,17 +1,24 @@
 package com.techchallenge.core.applications.ports;
 
-import com.techchallenge.core.domain.Produto;
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
+import com.techchallenge.core.domain.Produto;
 
 @Repository
 public interface ProdutoRepository extends JpaRepository<Produto, Long> {
 
-    Produto save(Produto produto);
+    @SuppressWarnings("unchecked")
+	Produto save(Produto produto);
 
+    @Query("from Produto p join fetch p.categoria where p.categoria.nome = :produtoCategoria")
     List<Produto> findByCategoriaNome(String produtoCategoria);
+    
+	@Query("from Produto p join fetch p.categoria")
+	List<Produto> findAll();
 
     void deleteById(Long produtoId);
 }

--- a/src/main/java/com/techchallenge/core/applications/service/ItemPedidoService.java
+++ b/src/main/java/com/techchallenge/core/applications/service/ItemPedidoService.java
@@ -1,8 +1,5 @@
 package com.techchallenge.core.applications.service;
 
-import java.time.OffsetDateTime;
-import java.util.List;
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -12,8 +9,6 @@ import com.techchallenge.core.applications.ports.ProdutoRepository;
 import com.techchallenge.core.domain.ItemPedido;
 import com.techchallenge.core.domain.Pedido;
 import com.techchallenge.core.domain.Produto;
-import com.techchallenge.core.domain.StatusPedido;
-import com.techchallenge.core.domain.exception.NegocioException;
 
 @Service
 public class ItemPedidoService {
@@ -27,30 +22,6 @@ public class ItemPedidoService {
     @Autowired
     private ProdutoRepository produtoRepository;
 
-    public List<Pedido> buscarPedidos() {
-        return pedidoRepository.findAll();
-    }
-
-    public Pedido buscarPedidoPorId(Long id) {
-        return pedidoRepository.findById(id).orElseThrow(() -> new NegocioException(
-                String.format("Não existe pedido com o id %d", id)));
-    }
-
-    public List<Pedido> buscarPedidosPorStatus(StatusPedido statusPedido) {
-        return pedidoRepository.findByStatus(statusPedido);
-    }
-
-    public void atualizarStatusDoPedido(Pedido pedido, StatusPedido statusPedido) {
-        pedido.setStatus(statusPedido);
-        pedidoRepository.save(pedido);
-    }
-    
-    public Pedido inicializar(Pedido pedido) {
-        pedido.setStatus(StatusPedido.GERACAO);
-        pedido.setDataSolicitacao(OffsetDateTime.now());
-        return pedidoRepository.save(pedido);
-    }
-    
     public ItemPedido adicionarItemAoPedido(Long idPedido, ItemPedido itemPedido) {
     	Pedido pedido = pedidoRepository.findById(idPedido).get();
     	Produto produto = produtoRepository.findById(itemPedido.getProduto().getId()).get();

--- a/src/main/java/com/techchallenge/core/applications/service/ItemPedidoService.java
+++ b/src/main/java/com/techchallenge/core/applications/service/ItemPedidoService.java
@@ -1,20 +1,31 @@
 package com.techchallenge.core.applications.service;
 
-import com.techchallenge.core.applications.ports.PedidoRepository;
-import com.techchallenge.core.domain.Pedido;
-import com.techchallenge.core.domain.StatusPedido;
-import com.techchallenge.core.domain.exception.NegocioException;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Service;
-
 import java.time.OffsetDateTime;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import com.techchallenge.core.applications.ports.ItemPedidoRepository;
+import com.techchallenge.core.applications.ports.PedidoRepository;
+import com.techchallenge.core.applications.ports.ProdutoRepository;
+import com.techchallenge.core.domain.ItemPedido;
+import com.techchallenge.core.domain.Pedido;
+import com.techchallenge.core.domain.Produto;
+import com.techchallenge.core.domain.StatusPedido;
+import com.techchallenge.core.domain.exception.NegocioException;
+
 @Service
-public class PedidoService {
+public class ItemPedidoService {
 
     @Autowired
     private PedidoRepository pedidoRepository;
+    
+    @Autowired
+    private ItemPedidoRepository itemPedidoRepository;
+    
+    @Autowired
+    private ProdutoRepository produtoRepository;
 
     public List<Pedido> buscarPedidos() {
         return pedidoRepository.findAll();
@@ -38,5 +49,18 @@ public class PedidoService {
         pedido.setStatus(StatusPedido.GERACAO);
         pedido.setDataSolicitacao(OffsetDateTime.now());
         return pedidoRepository.save(pedido);
+    }
+    
+    public ItemPedido adicionarItemAoPedido(Long idPedido, ItemPedido itemPedido) {
+    	Pedido pedido = pedidoRepository.findById(idPedido).get();
+    	Produto produto = produtoRepository.findById(itemPedido.getProduto().getId()).get();
+    	
+    	pedido.getItens().add(itemPedido);
+    	
+    	itemPedido.setPedido(pedido);
+    	itemPedido.setProduto(produto);
+    	itemPedido.calcularPrecoTotal();
+    	
+    	return itemPedidoRepository.save(itemPedido);
     }
 }

--- a/src/main/java/com/techchallenge/core/domain/Categoria.java
+++ b/src/main/java/com/techchallenge/core/domain/Categoria.java
@@ -1,10 +1,14 @@
 package com.techchallenge.core.domain;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
 
 @Entity
 public class Categoria {
@@ -14,6 +18,8 @@ public class Categoria {
     private Long id;
     @Column(nullable = false)
     private String nome;
+	@OneToMany(mappedBy = "categoria")
+	private List<Produto> produtos = new ArrayList<>();
 
     public Long getId() {
         return id;

--- a/src/main/java/com/techchallenge/core/domain/Pedido.java
+++ b/src/main/java/com/techchallenge/core/domain/Pedido.java
@@ -28,12 +28,12 @@ public class Pedido {
 	private List<ItemPedido> itens;
 	private BigDecimal valor;
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name="tipo_pagamento_id", nullable = false)
+    @JoinColumn(name="tipo_pagamento_id", nullable = true)
 	private TipoPagamento tipoPagamento;
 	@Enumerated(EnumType.STRING)
 	private StatusPedido status;
     @ManyToOne
-    @JoinColumn(name = "cliente_id", nullable = false)
+    @JoinColumn(name = "cliente_id", nullable = true)
 	private Cliente cliente;
 
 	@CreationTimestamp

--- a/src/main/java/com/techchallenge/core/domain/StatusPedido.java
+++ b/src/main/java/com/techchallenge/core/domain/StatusPedido.java
@@ -2,6 +2,7 @@ package com.techchallenge.core.domain;
 
 public enum StatusPedido {
 
+	GERACAO,
 	REALIZADO,
 	CANCELADO,
 	PREPARACAO,

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,1 +1,6 @@
 INSERT INTO tipo_pagamento (nome) VALUES ('QR Code');
+
+INSERT INTO categoria (nome) VALUES ('Lanche');
+INSERT INTO categoria (nome) VALUES ('Acompanhamento');
+INSERT INTO categoria (nome) VALUES ('Bebida');
+INSERT INTO categoria (nome) VALUES ('Sobremesa');


### PR DESCRIPTION
- Customização de queries JPA para evitar consultas com N+1;
- Inclusão de endpoint para cadastro de produto na plataforma;
- Inclusão de endpoint para geração de pedido "vazio";
- Inclusão de endpoint para cadastro de itens no pedido (associação de produto e pedido para geração do item).